### PR TITLE
feat: add tap and double tap support

### DIFF
--- a/example/src/screens/Playground/Playground.tsx
+++ b/example/src/screens/Playground/Playground.tsx
@@ -69,7 +69,7 @@ const Playground = ({}: PlaygroundProps) => {
           <Icon
             name="trash"
             size={18}
-            color={theme == 'dark' ? 'rgb(255, 59,48)' : 'rgb(255, 69,58)'}
+            color={theme === 'dark' ? 'rgb(255, 59,48)' : 'rgb(255, 69,58)'}
           />
         ),
         withSeperator: true,

--- a/src/components/holdItem/HoldItem.tsx
+++ b/src/components/holdItem/HoldItem.tsx
@@ -74,13 +74,12 @@ const HoldItemComponent = ({
 
   const deviceOrientation = useDeviceOrientation();
   const key = useMemo(() => `hold-item-${nanoid()}`, []);
-  const isHold = useMemo(() => !activateOn || activateOn === 'hold', [
-    activateOn,
-  ]);
   const menuHeight = useMemo(() => {
     const itemsWithSeperator = items.filter(item => item.withSeperator);
     return calculateMenuHeight(items.length, itemsWithSeperator.length);
   }, [items]);
+
+  const isHold = !activateOn || activateOn === 'hold';
 
   const activateAnimation = (ctx: any) => {
     'worklet';

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -57,4 +57,17 @@ export type HoldItemProps = {
    * bottom={true}
    */
   bottom?: boolean;
+
+  /**
+   * Set if you'd like a different tap activation
+   * @type string
+   * @default 'hold'
+   * @examples
+   * activateOn="hold"
+   */
+  activateOn?: 'tap' | 'double-tap' | 'hold';
+};
+
+export type GestureHandlerProps = {
+  children: React.ReactElement | React.ReactElement[];
 };


### PR DESCRIPTION
# Motivation
This adds tap and double gesture tap support while still animating child object just like with the hold gesture. I provide a `GestureHandler` wrapper which is either a LongPressGestureHandler or TapGestureHandler depending on a chosen `activateOn` prop.

Somewhat linked to #2 but I was interested in multi taps myself.