### PR TITLE
feat: add optional haptic feedback

### DIFF
--- a/example/src/screens/Playground/Playground.tsx
+++ b/example/src/screens/Playground/Playground.tsx
@@ -19,7 +19,6 @@ const Playground = ({}: PlaygroundProps) => {
       {
         isTitle: true,
         text: 'Actions',
-        onPress: () => {},
       },
       {
         text: 'Home',

--- a/example/src/screens/Whatsapp/ChatPage.tsx
+++ b/example/src/screens/Whatsapp/ChatPage.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo, useCallback } from 'react';
-import { StyleSheet } from 'react-native';
+import { Alert, StyleSheet } from 'react-native';
 
 import StyleGuide from '../../utilities/styleGuide';
 
@@ -14,6 +14,18 @@ const ChatPage = () => {
   const { theme } = useAppContext();
   const data = useMemo(() => mockWhatsAppData(1000), []);
 
+  const replyMessage = useCallback((messageId: string) => {
+    Alert.alert(`[ACTION]: REPLY' ${messageId}`);
+  }, []);
+
+  const copyMessage = useCallback((messageText: string) => {
+    Alert.alert(`[ACTION]: REPLY' ${messageText}`);
+  }, []);
+
+  const editMessage = useCallback((messageId: string, messageText: string) => {
+    Alert.alert(`[ACTION]: REPLY' ${messageId} - ${messageText}`);
+  }, []);
+
   const myMenu = useMemo(
     () => [
       {
@@ -25,9 +37,7 @@ const ChatPage = () => {
             color={theme === 'light' ? 'black' : 'white'}
           />
         ),
-        onPress: () => {
-          console.log('[ACTION]: Reply');
-        },
+        onPress: replyMessage,
       },
       {
         text: 'Copy',
@@ -38,9 +48,7 @@ const ChatPage = () => {
             color={theme === 'light' ? 'black' : 'white'}
           />
         ),
-        onPress: () => {
-          console.log('[ACTION]: Copy');
-        },
+        onPress: copyMessage,
       },
       {
         text: 'Edit',
@@ -51,7 +59,7 @@ const ChatPage = () => {
             color={theme === 'light' ? 'black' : 'white'}
           />
         ),
-        onPress: () => {},
+        onPress: editMessage,
       },
       {
         text: 'Pin',
@@ -87,7 +95,7 @@ const ChatPage = () => {
         onPress: () => {},
       },
     ],
-    [theme]
+    [theme, replyMessage, copyMessage, editMessage]
   );
 
   const otherMenu = useMemo(
@@ -101,9 +109,7 @@ const ChatPage = () => {
             color={theme === 'light' ? 'black' : 'white'}
           />
         ),
-        onPress: () => {
-          console.log('[ACTION]: Reply');
-        },
+        onPress: replyMessage,
       },
       {
         text: 'Copy',
@@ -114,9 +120,7 @@ const ChatPage = () => {
             color={theme === 'light' ? 'black' : 'white'}
           />
         ),
-        onPress: () => {
-          console.log('[ACTION]: Copy');
-        },
+        onPress: copyMessage,
       },
       {
         text: 'Pin',
@@ -152,7 +156,7 @@ const ChatPage = () => {
         onPress: () => {},
       },
     ],
-    [theme]
+    [theme, replyMessage, copyMessage]
   );
 
   const renderMessage = useCallback(

--- a/example/src/screens/Whatsapp/MessageItem.tsx
+++ b/example/src/screens/Whatsapp/MessageItem.tsx
@@ -32,6 +32,14 @@ const MessageItemComp = ({
     };
   }, [theme]);
 
+  const methodProps = useMemo(() => {
+    return {
+      Reply: [message.id],
+      Copy: [message.text],
+      Edit: [message.id, message.text],
+    };
+  }, [message]);
+
   return (
     <View
       style={[
@@ -41,6 +49,7 @@ const MessageItemComp = ({
       ]}
     >
       <HoldItem
+        methodParams={methodProps}
         items={message.fromMe ? senderMenu : receiverMenu}
         // eslint-disable-next-line react-native/no-inline-styles
         containerStyles={{

--- a/example/src/utilities/data.ts
+++ b/example/src/utilities/data.ts
@@ -1,10 +1,11 @@
 import * as Faker from 'faker';
+import { nanoid } from 'nanoid/non-secure';
 
 export const mockWhatsAppData = (count = 50) =>
   Array(count)
     .fill(0)
-    .map((_, index) => ({
-      id: index + 1,
+    .map(_ => ({
+      id: nanoid(),
       text: Faker.lorem.sentence(30),
       fromMe: Math.random() < 0.5,
       time: Faker.name.firstName(),

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@gorhom/portal": "^1.0.3",
     "expo-blur": "^9.0.0",
+    "expo-haptics": "^9.0.0",
     "lodash.isequal": "^4.5.0",
     "nanoid": "^3.1.20"
   },

--- a/src/components/holdItem/HoldItem.tsx
+++ b/src/components/holdItem/HoldItem.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native-gesture-handler';
 import Animated, {
   measure,
+  runOnJS,
   useAnimatedGestureHandler,
   useAnimatedProps,
   useAnimatedRef,
@@ -21,6 +22,12 @@ import Animated, {
   withSpring,
   useAnimatedReaction,
 } from 'react-native-reanimated';
+
+// Optional Haptic Feedback
+let ReactNativeHaptic: any;
+try {
+  ReactNativeHaptic = require('react-native-haptic-feedback').default;
+} catch (error) {}
 
 // Utils
 import {
@@ -55,6 +62,7 @@ const HoldItemComponent = ({
   disableMove,
   menuAnchorPosition,
   activateOn,
+  hapticFeedback,
   methodParams,
   children,
 }: HoldItemProps) => {
@@ -155,6 +163,16 @@ const HoldItemComponent = ({
     });
   };
 
+  const hapticResponse = () => {
+    const haptic =
+      !hapticFeedback || hapticFeedback === 'enabled'
+        ? 'impactMedium'
+        : hapticFeedback;
+    ReactNativeHaptic.trigger(haptic, {
+      enableVibrateFallback: true,
+    });
+  };
+
   const onCompletion = (isFinised: boolean) => {
     'worklet';
     const isListValid = items && items.length > 0;
@@ -162,6 +180,11 @@ const HoldItemComponent = ({
       state.value = CONTEXT_MENU_STATE.ACTIVE;
       isActive.value = true;
       scaleBack();
+      if (hapticFeedback !== 'none') {
+        if (ReactNativeHaptic) {
+          runOnJS(hapticResponse)();
+        }
+      }
     }
 
     isAnimationStarted.value = false;

--- a/src/components/holdItem/HoldItem.tsx
+++ b/src/components/holdItem/HoldItem.tsx
@@ -23,11 +23,7 @@ import Animated, {
   useAnimatedReaction,
 } from 'react-native-reanimated';
 
-// Optional Haptic Feedback
-let ReactNativeHaptic: any;
-try {
-  ReactNativeHaptic = require('react-native-haptic-feedback').default;
-} catch (error) {}
+import * as Haptics from 'expo-haptics';
 
 // Utils
 import {
@@ -164,13 +160,23 @@ const HoldItemComponent = ({
   };
 
   const hapticResponse = () => {
-    const haptic =
-      !hapticFeedback || hapticFeedback === 'enabled'
-        ? 'impactMedium'
-        : hapticFeedback;
-    ReactNativeHaptic.trigger(haptic, {
-      enableVibrateFallback: true,
-    });
+    const style = !hapticFeedback ? 'Medium' : hapticFeedback;
+    switch (style) {
+      case `Selection`:
+        Haptics.selectionAsync();
+        break;
+      case `Light`:
+      case `Medium`:
+      case `Heavy`:
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle[style]);
+        break;
+      case `Success`:
+      case `Warning`:
+      case `Error`:
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType[style]);
+        break;
+      default:
+    }
   };
 
   const onCompletion = (isFinised: boolean) => {
@@ -180,10 +186,8 @@ const HoldItemComponent = ({
       state.value = CONTEXT_MENU_STATE.ACTIVE;
       isActive.value = true;
       scaleBack();
-      if (hapticFeedback !== 'none') {
-        if (ReactNativeHaptic) {
-          runOnJS(hapticResponse)();
-        }
+      if (hapticFeedback !== 'None') {
+        runOnJS(hapticResponse)();
       }
     }
 

--- a/src/components/holdItem/HoldItem.tsx
+++ b/src/components/holdItem/HoldItem.tsx
@@ -55,6 +55,7 @@ const HoldItemComponent = ({
   disableMove,
   menuAnchorPosition,
   activateOn,
+  methodParams,
   children,
 }: HoldItemProps) => {
   const { state, menuProps } = useInternal();
@@ -143,6 +144,7 @@ const HoldItemComponent = ({
       menuHeight: menuHeight,
       items,
       transformValue: transformValue.value,
+      methodParams: methodParams || {},
     };
   };
 

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -10,6 +10,29 @@ export type HoldItemProps = {
    */
   items: MenuItemProps[];
 
+  /**
+   * Object of keys that same name with items to match parameters to onPress actions.
+   * @type { [name: string]: (string | number)[] }
+   * @examples
+   * ```js
+   * const items = [
+   *  {text: 'Reply', onPress=(messageId)=>{}},
+   *  {text: 'Copy', onPress=(messageText)=>{}},
+   * ]
+   * ...
+   * <HoldItem
+   *    items={items}
+   *    methodParams={{
+   *      Reply: ['dd443224-7f43'],
+   *      Copy: ['Hello World!']
+   *    }}
+   * ><View/></HoldItem>
+   * ```
+   */
+  methodParams: {
+    [name: string]: (string | number)[];
+  };
+
   children: React.ReactElement | React.ReactElement[];
 
   /**

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -93,20 +93,19 @@ export type HoldItemProps = {
   /**
    * Set if you'd like to enable haptic feedback on activation
    * @type string
-   * @default 'impactMedium'
+   * @default 'Medium'
    * @examples
    * hapticFeedback="none"
    */
   hapticFeedback?:
-    | 'enabled'
-    | 'none'
-    | 'selection'
-    | 'impactLight'
-    | 'impactMedium'
-    | 'impactHeavy'
-    | 'notificationSuccess'
-    | 'notificationWarning'
-    | 'notificationError';
+    | 'None'
+    | 'Selection'
+    | 'Light'
+    | 'Medium'
+    | 'Heavy'
+    | 'Success'
+    | 'Warning'
+    | 'Error';
 };
 
 export type GestureHandlerProps = {

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -89,6 +89,24 @@ export type HoldItemProps = {
    * activateOn="hold"
    */
   activateOn?: 'tap' | 'double-tap' | 'hold';
+
+  /**
+   * Set if you'd like to enable haptic feedback on activation
+   * @type string
+   * @default 'impactMedium'
+   * @examples
+   * hapticFeedback="none"
+   */
+  hapticFeedback?:
+    | 'enabled'
+    | 'none'
+    | 'selection'
+    | 'impactLight'
+    | 'impactMedium'
+    | 'impactHeavy'
+    | 'notificationSuccess'
+    | 'notificationWarning'
+    | 'notificationError';
 };
 
 export type GestureHandlerProps = {

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -95,7 +95,7 @@ export type HoldItemProps = {
    * @type string
    * @default 'Medium'
    * @examples
-   * hapticFeedback="none"
+   * hapticFeedback="None"
    */
   hapticFeedback?:
     | 'None'

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -30,7 +30,7 @@ type MenuItemComponentProps = {
 };
 
 const MenuItemComponent = ({ item, isLast, theme }: MenuItemComponentProps) => {
-  const { state } = useInternal();
+  const { state, menuProps } = useInternal();
 
   const borderStyles = useAnimatedStyle(() => {
     const borderBottomColor =
@@ -58,9 +58,11 @@ const MenuItemComponent = ({ item, isLast, theme }: MenuItemComponentProps) => {
 
   const handleOnPress = useCallback(() => {
     if (!item.isTitle) {
-      if (item.onPress) item.onPress();
+      const params = menuProps.value.methodParams[item.text] || [];
+      if (item.onPress) item.onPress(...params);
       state.value = CONTEXT_MENU_STATE.END;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state, item]);
 
   return (

--- a/src/components/menu/types.d.ts
+++ b/src/components/menu/types.d.ts
@@ -3,7 +3,7 @@ import { TransformOriginAnchorPosition } from '../../utils/calculations';
 export type MenuItemProps = {
   text: string;
   icon?: () => React.ReactNode;
-  onPress: () => void;
+  onPress?: (arg?: string | number) => void;
   isTitle?: boolean;
   isDestructive?: boolean;
   withSeperator?: boolean;
@@ -22,4 +22,7 @@ export type MenuInternalProps = {
   anchorPosition: TransformOriginAnchorPosition;
   menuHeight: number;
   transformValue: number;
+  methodParams: {
+    [name: string]: (string | number)[];
+  };
 };

--- a/src/components/provider/Provider.tsx
+++ b/src/components/provider/Provider.tsx
@@ -34,6 +34,7 @@ const ProviderComponent = ({
     anchorPosition: 'top-center',
     menuHeight: 0,
     transformValue: 0,
+    methodParams: {},
   });
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4157,6 +4157,11 @@ expo-blur@^9.0.0:
   resolved "https://registry.yarnpkg.com/expo-blur/-/expo-blur-9.0.0.tgz#6447a65dba3f14532406d9c5227622b3e7d1abf7"
   integrity sha512-zqZENclTYBtVAZOsnDROT5PQ9MbMxa5A36J+aU2NiV6MqLYlUh/b/FnR0JPAuY4F6jS6U7sYiAlStzIXpLd7XQ==
 
+expo-haptics@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/expo-haptics/-/expo-haptics-9.0.0.tgz#a01605634ff9b8a4dc8023f5430278be874f525b"
+  integrity sha512-jBYgclyBVuGiqFPxdYSpIE5OEpWodu1B8fsqDLVIOWjdACnKVGsaBpSF6W4Xq0wVRvoak7C4Oz7ISV08rtPMOw==
+
 extend-shallow@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-1.1.4.tgz#19d6bf94dfc09d76ba711f39b872d21ff4dd9071"


### PR DESCRIPTION
# Motivation
I was hoping to start a discussion about haptic feedback. This library nails down the "pop" for a hold menu wonderfully, but it's hard to not notice that it's missing any sort of haptics. I found that you at one point added expo-haptics in c3e8105a05f229cbc3a25488f9b9010f3b5d783d then removed it the next commit. Would you mind sharing as to why? 

This somewhat opinionated PR is dependent on `react-native-haptic-feedback` and in order to experience the haptics you have to installed it. But it isn't necessary to have it installed for the `react-native-hold-menu` library to work. But it does give a quick and easy out of the box experience for users of this library. Let me know what you think and if this is a path you'd like to go down.