### PR TITLE
feat: new prop to pass params to onPress handlers

### DIFF
--- a/example/src/screens/Whatsapp/MessageItem.tsx
+++ b/example/src/screens/Whatsapp/MessageItem.tsx
@@ -49,7 +49,7 @@ const MessageItemComp = ({
       ]}
     >
       <HoldItem
-        methodParams={methodProps}
+        actionParams={methodProps}
         items={message.fromMe ? senderMenu : receiverMenu}
         // eslint-disable-next-line react-native/no-inline-styles
         containerStyles={{

--- a/src/components/holdItem/HoldItem.tsx
+++ b/src/components/holdItem/HoldItem.tsx
@@ -59,7 +59,7 @@ const HoldItemComponent = ({
   menuAnchorPosition,
   activateOn,
   hapticFeedback,
-  methodParams,
+  actionParams,
   children,
 }: HoldItemProps) => {
   const { state, menuProps } = useInternal();
@@ -148,7 +148,7 @@ const HoldItemComponent = ({
       menuHeight: menuHeight,
       items,
       transformValue: transformValue.value,
-      methodParams: methodParams || {},
+      actionParams: actionParams || {},
     };
   };
 

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -22,14 +22,14 @@ export type HoldItemProps = {
    * ...
    * <HoldItem
    *    items={items}
-   *    methodParams={{
+   *    actionParams={{
    *      Reply: ['dd443224-7f43'],
    *      Copy: ['Hello World!']
    *    }}
    * ><View/></HoldItem>
    * ```
    */
-  methodParams?: {
+  actionParams?: {
     [name: string]: (string | number)[];
   };
 

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -16,8 +16,8 @@ export type HoldItemProps = {
    * @examples
    * ```js
    * const items = [
-   *  {text: 'Reply', onPress=(messageId)=>{}},
-   *  {text: 'Copy', onPress=(messageText)=>{}},
+   *  {text: 'Reply', onPress: (messageId) => {}},
+   *  {text: 'Copy', onPress: (messageText) => {}},
    * ]
    * ...
    * <HoldItem
@@ -29,7 +29,7 @@ export type HoldItemProps = {
    * ><View/></HoldItem>
    * ```
    */
-  methodParams: {
+  methodParams?: {
     [name: string]: (string | number)[];
   };
 

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -30,7 +30,7 @@ export type HoldItemProps = {
    * ```
    */
   actionParams?: {
-    [name: string]: (string | number)[];
+    [name: string]: any[];
   };
 
   children: React.ReactElement | React.ReactElement[];

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -58,7 +58,7 @@ const MenuItemComponent = ({ item, isLast, theme }: MenuItemComponentProps) => {
 
   const handleOnPress = useCallback(() => {
     if (!item.isTitle) {
-      const params = menuProps.value.methodParams[item.text] || [];
+      const params = menuProps.value.actionParams[item.text] || [];
       if (item.onPress) item.onPress(...params);
       state.value = CONTEXT_MENU_STATE.END;
     }

--- a/src/components/menu/types.d.ts
+++ b/src/components/menu/types.d.ts
@@ -22,7 +22,7 @@ export type MenuInternalProps = {
   anchorPosition: TransformOriginAnchorPosition;
   menuHeight: number;
   transformValue: number;
-  methodParams: {
+  actionParams: {
     [name: string]: (string | number)[];
   };
 };

--- a/src/components/provider/Provider.tsx
+++ b/src/components/provider/Provider.tsx
@@ -34,7 +34,7 @@ const ProviderComponent = ({
     anchorPosition: 'top-center',
     menuHeight: 0,
     transformValue: 0,
-    methodParams: {},
+    actionParams: {},
   });
 
   useEffect(() => {

--- a/website/docs/props.md
+++ b/website/docs/props.md
@@ -36,7 +36,7 @@ Check out the other examples [here](examples).
 
 Object of keys that same name with items to match parameters to onPress actions. If you want to pass different parameters for hold item to menu item `onPress` handlers ([check WhatsApp example](https://github.com/enesozturk/react-native-hold-menu/blob/main/example/src/screens/Whatsapp/MessageItem.tsx)), you need to use this prop to set params per HoldItem.
 
-The reason provide action params with another prop is make it able to
+> The reason provide action params with another prop is make it able to pass with shared value without performance issues.
 
 | type                      | required |
 | ------------------------- | -------- |
@@ -59,15 +59,43 @@ const items = [
 ><View/></HoldItem>
 ```
 
+### `activateOn`
+
+Type of behavior to activate menu action.
+
+| type                            | default | required |
+| ------------------------------- | ------- | -------- |
+| tap <br/> double-tap <br/> hold | hold    | NO       |
+
+#### Example
+
+```tsx
+<HoldItem activateOn="double-tap" />
+```
+
+### `hapticFeedback`
+
+Type of haptic feedback behavior.
+
+| type                                                                                              | default | required |
+| ------------------------------------------------------------------------------------------------- | ------- | -------- |
+| None <br/> Selection <br/> Light <br/> Medium <br/> Heavy <br/> Success <br/> Warning <br/> Error | Medium  | NO       |
+
+#### Example
+
+```tsx
+<HoldItem hapticFeedback="Heavy" />
+```
+
 ### `menuAnchorPosition`
 
 Menu anchor position is calculated automaticly. But you can override the calculation by passing an anchor position.
-Auto calculation will be "top-left", "top-center" or "top-right". If you want to open menu from bottom, you need to use
-"bottom-left", "bottom-center" or "bottom-right". Or if you want to use auto calculation for bottom, see [`bottom`](#bottom) prop.
+Auto calculation will be `top-left`, `top-center` or `top-right`. If you want to open menu from bottom, you need to use
+`bottom-left`, `bottom-center` or `bottom-right`. Or if you want to use auto calculation for bottom, see [`bottom`](#bottom) prop.
 
-| type                                                                                           | required |
-| ---------------------------------------------------------------------------------------------- | -------- |
-| "top-center" \| "top-left" \| "top-right"\| "bottom-center" \| "bottom-left" \| "bottom-right" | NO       |
+| type                                                                                               | required |
+| -------------------------------------------------------------------------------------------------- | -------- |
+| top-center <br/> top-left <br/> top-right <br/> bottom-center <br/> bottom-left <br/> bottom-right | NO       |
 
 #### Example
 

--- a/website/docs/props.md
+++ b/website/docs/props.md
@@ -32,6 +32,33 @@ Array of menu items.
 
 Check out the other examples [here](examples).
 
+### `actionParams`
+
+Object of keys that same name with items to match parameters to onPress actions. If you want to pass different parameters for hold item to menu item `onPress` handlers ([check WhatsApp example](https://github.com/enesozturk/react-native-hold-menu/blob/main/example/src/screens/Whatsapp/MessageItem.tsx)), you need to use this prop to set params per HoldItem.
+
+The reason provide action params with another prop is make it able to
+
+| type                      | required |
+| ------------------------- | -------- |
+| { [name: string]: any[] } | NO       |
+
+#### Example
+
+```tsx
+const items = [
+ {text: 'Reply', onPress: (messageId) => {}},
+ {text: 'Copy', onPress: (messageText, index) => {}},
+]
+
+<HoldItem
+   items={items}
+   actionParams={{
+     Reply: ['dd443224-7f43'],
+     Copy: ['Hello World!', 1]
+   }}
+><View/></HoldItem>
+```
+
 ### `menuAnchorPosition`
 
 Menu anchor position is calculated automaticly. But you can override the calculation by passing an anchor position.


### PR DESCRIPTION
## Motivation

To be able to pass different parameters to `onPress` function in menu list items, especially list examples like https://github.com/enesozturk/react-native-hold-menu/issues/4, it is needed to move parameters with shared value without changing menu list. Changing list per element is causing performance issues.

I created a new prop called `methodParams` to be able to solve this issue. Here is the example usage of it:

 ```js
 const items = [
  {text: 'Reply', onPress: (messageId) => {}},
  {text: 'Copy', onPress: (messageText) => {}}
 ]

 <HoldItem
    items={items}
    methodParams={{
      Reply: ['dd443224-7f43'],
      Copy: ['Hello World!']
    }}
 >
{/* Your content */}
</HoldItem>
 ```