### PR TITLE
feat: new icon component usage logic

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -26,8 +26,9 @@ import Clubhouse, {
   ClubhouseNavButtonRight,
 } from './screens/Clubhouse';
 
-// Hold Menu
+// Components
 import { HoldMenuProvider } from 'react-native-hold-menu';
+import FeatherIcon from 'react-native-vector-icons/Feather';
 
 // Utils
 import { AppContext, IAppContext } from './context/internal';
@@ -69,7 +70,7 @@ const App = () => {
         <StatusBar
           barStyle={state.theme === 'light' ? 'dark-content' : 'light-content'}
         />
-        <HoldMenuProvider theme={state.theme}>
+        <HoldMenuProvider iconComponent={FeatherIcon} theme={state.theme}>
           <NavigationContainer>
             <Stack.Navigator
               initialRouteName="Home"
@@ -103,16 +104,16 @@ const App = () => {
               />
               <Stack.Screen
                 name="Clubhouse"
-                options={{
+                options={({ navigation: { goBack } }) => ({
                   headerStyle: {
                     backgroundColor: StyleGuide.palette.clubhouse.background,
                     shadowColor: StyleGuide.palette.clubhouse.background,
                     height: StyleGuide.spacing * 12,
                   },
                   headerTintColor: StyleGuide.palette.light.color,
-                  headerLeft: () => <ClubhouseNavButtonLeft />,
+                  headerLeft: () => <ClubhouseNavButtonLeft goBack={goBack} />,
                   headerRight: () => <ClubhouseNavButtonRight />,
-                }}
+                })}
                 component={Clubhouse}
               />
             </Stack.Navigator>

--- a/example/src/screens/Clubhouse/ClubhouseNavButtonLeft.tsx
+++ b/example/src/screens/Clubhouse/ClubhouseNavButtonLeft.tsx
@@ -1,13 +1,13 @@
 import React, { memo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, Pressable } from 'react-native';
 
 import Icons from 'react-native-vector-icons/Feather';
 
 import { HoldItem } from 'react-native-hold-menu';
 
-const ClubhouseNavButtonLeft = () => {
+const ClubhouseNavButtonLeft = ({ goBack }: { goBack: () => void }) => {
   return (
-    <View style={styles.container}>
+    <Pressable style={styles.container} onPress={goBack}>
       <HoldItem
         items={[
           { text: '@enesozt', onPress: () => {} },
@@ -16,7 +16,7 @@ const ClubhouseNavButtonLeft = () => {
       >
         <Icons name="chevron-left" size={32} style={styles.icon} />
       </HoldItem>
-    </View>
+    </Pressable>
   );
 };
 

--- a/example/src/screens/Playground/Playground.tsx
+++ b/example/src/screens/Playground/Playground.tsx
@@ -1,22 +1,13 @@
 import React, { memo, useMemo } from 'react';
 import { View } from 'react-native';
 
-import { HoldItem, HoldMenuIcon } from 'react-native-hold-menu';
+import { HoldItem } from 'react-native-hold-menu';
 
 import styles from './styles';
 import { useAppContext } from '../../hooks/useAppContext';
 import StyleGuide from '../../utilities/styleGuide';
-import FeatherIcon from 'react-native-vector-icons/Feather';
 
 interface PlaygroundProps {}
-
-type IconProps = {
-  name: string;
-};
-
-const Icon = ({ name }: IconProps) => {
-  return <HoldMenuIcon name={name} iconComponent={FeatherIcon} />;
-};
 
 const Playground = ({}: PlaygroundProps) => {
   const { theme } = useAppContext();
@@ -28,14 +19,14 @@ const Playground = ({}: PlaygroundProps) => {
     },
     {
       text: 'Home',
-      icon: () => <Icon name="home" />,
+      icon: 'home',
       onPress: () => {
         console.log('[ACTION]: Home');
       },
     },
     {
       text: 'Edit',
-      icon: () => <Icon name="edit" />,
+      icon: 'edit',
       onPress: () => {
         console.log('[ACTION]: Edit');
       },
@@ -45,14 +36,14 @@ const Playground = ({}: PlaygroundProps) => {
       onPress: () => {
         console.log('[ACTION]: Download');
       },
-      icon: () => <Icon name="download" />,
+      icon: 'download',
     },
     {
       text: 'Delete',
       onPress: () => {
         console.log('[ACTION]: Delete');
       },
-      icon: () => <Icon name="trash" />,
+      icon: 'trash',
       withSeperator: true,
       isDestructive: true,
     },
@@ -61,14 +52,14 @@ const Playground = ({}: PlaygroundProps) => {
       onPress: () => {
         console.log('[ACTION]: Share');
       },
-      icon: () => <Icon name="share" />,
+      icon: 'share',
     },
     {
       text: 'More',
       onPress: () => {
         console.log('[ACTION]: More');
       },
-      icon: () => <Icon name="more-horizontal" />,
+      icon: 'more-horizontal',
     },
   ];
 

--- a/example/src/screens/Playground/Playground.tsx
+++ b/example/src/screens/Playground/Playground.tsx
@@ -1,108 +1,76 @@
 import React, { memo, useMemo } from 'react';
 import { View } from 'react-native';
 
-import { HoldItem } from 'react-native-hold-menu';
+import { HoldItem, HoldMenuIcon } from 'react-native-hold-menu';
 
 import styles from './styles';
 import { useAppContext } from '../../hooks/useAppContext';
 import StyleGuide from '../../utilities/styleGuide';
-import Icon from 'react-native-vector-icons/Feather';
+import FeatherIcon from 'react-native-vector-icons/Feather';
 
 interface PlaygroundProps {}
+
+type IconProps = {
+  name: string;
+};
+
+const Icon = ({ name }: IconProps) => {
+  return <HoldMenuIcon name={name} iconComponent={FeatherIcon} />;
+};
 
 const Playground = ({}: PlaygroundProps) => {
   const { theme } = useAppContext();
 
-  // [TODO]: MenuItem does not render icon
-  const items = useMemo(
-    () => [
-      {
-        isTitle: true,
-        text: 'Actions',
+  const items = [
+    {
+      isTitle: true,
+      text: 'Actions',
+    },
+    {
+      text: 'Home',
+      icon: () => <Icon name="home" />,
+      onPress: () => {
+        console.log('[ACTION]: Home');
       },
-      {
-        text: 'Home',
-        icon: () => (
-          <Icon
-            name="home"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: () => {
-          console.log('[ACTION]: Home');
-        },
+    },
+    {
+      text: 'Edit',
+      icon: () => <Icon name="edit" />,
+      onPress: () => {
+        console.log('[ACTION]: Edit');
       },
-      {
-        text: 'Edit',
-        icon: () => (
-          <Icon
-            name="edit"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: () => {
-          console.log('[ACTION]: Edit');
-        },
+    },
+    {
+      text: 'Download',
+      onPress: () => {
+        console.log('[ACTION]: Download');
       },
-      {
-        text: 'Download',
-        onPress: () => {
-          console.log('[ACTION]: Download');
-        },
-        icon: () => (
-          <Icon
-            name="download"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
+      icon: () => <Icon name="download" />,
+    },
+    {
+      text: 'Delete',
+      onPress: () => {
+        console.log('[ACTION]: Delete');
       },
-      {
-        text: 'Delete',
-        onPress: () => {
-          console.log('[ACTION]: Delete');
-        },
-        icon: () => (
-          <Icon
-            name="trash"
-            size={18}
-            color={theme === 'dark' ? 'rgb(255, 59,48)' : 'rgb(255, 69,58)'}
-          />
-        ),
-        withSeparator: true,
-        isDestructive: true,
+      icon: () => <Icon name="trash" />,
+      withSeperator: true,
+      isDestructive: true,
+    },
+    {
+      text: 'Share',
+      onPress: () => {
+        console.log('[ACTION]: Share');
       },
-      {
-        text: 'Share',
-        onPress: () => {
-          console.log('[ACTION]: Share');
-        },
-        icon: () => (
-          <Icon
-            name="share"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
+      icon: () => <Icon name="share" />,
+    },
+    {
+      text: 'More',
+      onPress: () => {
+        console.log('[ACTION]: More');
       },
-      {
-        text: 'More',
-        onPress: () => {
-          console.log('[ACTION]: More');
-        },
-        icon: () => (
-          <Icon
-            name="more-horizontal"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-      },
-    ],
-    [theme]
-  );
+      icon: () => <Icon name="more-horizontal" />,
+    },
+  ];
 
   const themeStyles = useMemo(() => {
     return {

--- a/example/src/screens/Playground/styles.ts
+++ b/example/src/screens/Playground/styles.ts
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
   },
   item: {
     width: WINDOW_WIDTH / 5,
-    height: 70,
+    height: WINDOW_WIDTH / 5,
     paddingVertical: StyleGuide.spacing,
     borderRadius: StyleGuide.spacing * 1.5,
     display: 'flex',

--- a/example/src/screens/Telegram/Telegram.tsx
+++ b/example/src/screens/Telegram/Telegram.tsx
@@ -6,8 +6,6 @@ import { ContactsScreen, ChatScreen, SettingsScreen } from './Pages';
 import StyleGuide from '../../utilities/styleGuide';
 import { useAppContext } from '../../hooks/useAppContext';
 
-import Icon from 'react-native-vector-icons/Feather';
-
 const Tab = createBottomTabNavigator();
 
 interface TelegramProps {}
@@ -19,51 +17,33 @@ const Telegram = ({}: TelegramProps) => {
     () => [
       {
         text: 'Add Account',
-        icon: () => (
-          <Icon
-            name="plus"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
+        icon: 'plus',
         onPress: () => {
           console.log('[ACTION]: Add Account');
         },
       },
       {
         text: 'Enes Ozturk',
-        icon: () => (
-          <Icon
-            name="user"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
+        icon: 'user',
         onPress: () => {
           console.log('[ACTION]: Profile');
         },
       },
     ],
-    [theme]
+    []
   );
 
   const chatMenu = useMemo(
     () => [
       {
         text: 'Add Folder',
-        icon: () => (
-          <Icon
-            name="plus"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
+        icon: 'plus',
         onPress: () => {
           console.log('[ACTION]: Add Folder');
         },
       },
     ],
-    [theme]
+    []
   );
 
   const themeStyles = useMemo(() => {

--- a/example/src/screens/Whatsapp/ChatPage.tsx
+++ b/example/src/screens/Whatsapp/ChatPage.tsx
@@ -8,8 +8,6 @@ import { mockWhatsAppData } from '../../utilities/data';
 import { useAppContext } from '../../hooks/useAppContext';
 import { HoldMenuFlatList } from 'react-native-hold-menu';
 
-import Icon from 'react-native-vector-icons/Feather';
-
 const ChatPage = () => {
   const { theme } = useAppContext();
   const data = useMemo(() => mockWhatsAppData(1000), []);
@@ -26,138 +24,66 @@ const ChatPage = () => {
     Alert.alert(`[ACTION]: REPLY' ${messageId} - ${messageText}`);
   }, []);
 
-  const myMenu = useMemo(
-    () => [
-      {
-        text: 'Reply',
-        icon: () => (
-          <Icon
-            name="corner-down-left"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: replyMessage,
-      },
-      {
-        text: 'Copy',
-        icon: () => (
-          <Icon
-            name="copy"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: copyMessage,
-      },
-      {
-        text: 'Edit',
-        icon: () => (
-          <Icon
-            name="edit"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: editMessage,
-      },
-      {
-        text: 'Pin',
-        icon: () => (
-          <Icon
-            name="map-pin"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: () => {},
-      },
-      {
-        text: 'Forward',
-        icon: () => (
-          <Icon
-            name="corner-up-right"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: () => {},
-      },
-      {
-        text: 'Delete',
-        icon: () => (
-          <Icon
-            name="trash-2"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: () => {},
-      },
-    ],
-    [theme, replyMessage, copyMessage, editMessage]
-  );
+  const myMenu = [
+    {
+      text: 'Reply1',
+      icon: 'corner-down-left',
+      onPresss: replyMessage,
+    },
+    {
+      text: 'Copy1',
+      icon: 'copy',
+      onPress: copyMessage,
+    },
+    {
+      text: 'Edit1',
+      icon: 'home',
+      onPress: editMessage,
+    },
+    {
+      text: 'Pin1',
+      icon: 'map-pin',
+      onPress: () => {},
+    },
+    {
+      text: 'Forward1',
+      icon: 'corner-up-right',
+      onPress: () => {},
+    },
+    {
+      text: 'Delete1',
+      icon: 'trash-2',
+      onPress: () => {},
+    },
+  ];
 
-  const otherMenu = useMemo(
-    () => [
-      {
-        text: 'Reply',
-        icon: () => (
-          <Icon
-            name="corner-down-left"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: replyMessage,
-      },
-      {
-        text: 'Copy',
-        icon: () => (
-          <Icon
-            name="copy"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: copyMessage,
-      },
-      {
-        text: 'Pin',
-        icon: () => (
-          <Icon
-            name="map-pin"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: () => {},
-      },
-      {
-        text: 'Forward',
-        icon: () => (
-          <Icon
-            name="corner-up-right"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: () => {},
-      },
-      {
-        text: 'Delete',
-        icon: () => (
-          <Icon
-            name="trash-2"
-            size={18}
-            color={theme === 'light' ? 'black' : 'white'}
-          />
-        ),
-        onPress: () => {},
-      },
-    ],
-    [theme, replyMessage, copyMessage]
-  );
+  const otherMenu = [
+    {
+      text: 'Reply',
+      icon: 'corner-down-left',
+      onPress: () => {},
+    },
+    {
+      text: 'Copy',
+      icon: 'copy',
+      onPress: copyMessage,
+    },
+    {
+      text: 'Pin',
+      icon: 'map-pin',
+      onPress: () => {},
+    },
+    {
+      text: 'Forward',
+      icon: 'corner-up-right',
+      onPress: () => {},
+    },
+    {
+      text: 'Delete',
+      icon: 'trash-2',
+      onPress: () => {},
+    },
+  ];
 
   const renderMessage = useCallback(
     ({ item }) => (

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -1,0 +1,33 @@
+import React, { memo } from 'react';
+
+import Animated, { useAnimatedProps } from 'react-native-reanimated';
+import { useInternal } from '../../hooks';
+
+type IconComponentProps = {
+  name: string;
+  size: number;
+  animatedProps: Partial<{ color: string }>;
+};
+
+// Update iconComponent type, React.ComponentClass<IconComponentProps, any>
+type IconProps = {
+  iconComponent: any;
+  name: string;
+};
+
+const Icon = ({ iconComponent, name }: IconProps) => {
+  const { theme } = useInternal();
+  let AnimatedIcon = Animated.createAnimatedComponent<IconComponentProps>(
+    iconComponent
+  );
+
+  const iconProps = useAnimatedProps(() => {
+    return {
+      color: theme.value === 'light' ? 'black' : 'white',
+    };
+  }, [theme]);
+
+  return <AnimatedIcon name={name} size={18} animatedProps={iconProps} />;
+};
+
+export default memo(Icon);

--- a/src/components/icon/index.ts
+++ b/src/components/icon/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Icon';

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useCallback } from 'react';
-import { TouchableOpacity, Text } from 'react-native';
+import React, { useCallback } from 'react';
+import { TouchableOpacity } from 'react-native';
 import { TouchableOpacity as GHTouchableOpacity } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 
@@ -26,15 +26,14 @@ const AnimatedTouchable = Animated.createAnimatedComponent(ItemComponent);
 type MenuItemComponentProps = {
   item: MenuItemProps;
   isLast?: boolean;
-  theme: 'light' | 'dark';
 };
 
-const MenuItemComponent = ({ item, isLast, theme }: MenuItemComponentProps) => {
-  const { state, menuProps } = useInternal();
+const MenuItemComponent = ({ item, isLast }: MenuItemComponentProps) => {
+  const { state, theme, menuProps } = useInternal();
 
   const borderStyles = useAnimatedStyle(() => {
     const borderBottomColor =
-      theme === 'dark' ? BORDER_DARK_COLOR : BORDER_LIGHT_COLOR;
+      theme.value === 'dark' ? BORDER_DARK_COLOR : BORDER_LIGHT_COLOR;
 
     return {
       borderBottomColor,
@@ -42,15 +41,15 @@ const MenuItemComponent = ({ item, isLast, theme }: MenuItemComponentProps) => {
     };
   }, [theme, isLast]);
 
-  const textColor = useMemo(() => {
+  const textColor = useAnimatedStyle(() => {
     return {
       color: item.isTitle
         ? MENU_TITLE_COLOR
         : item.isDestructive
-        ? theme === 'dark'
+        ? theme.value === 'dark'
           ? MENU_TEXT_DESTRUCTIVE_COLOR_DARK
           : MENU_TEXT_DESTRUCTIVE_COLOR_LIGHT
-        : theme === 'dark'
+        : theme.value === 'dark'
         ? MENU_TEXT_DARK_COLOR
         : MENU_TEXT_LIGHT_COLOR,
     };
@@ -72,17 +71,17 @@ const MenuItemComponent = ({ item, isLast, theme }: MenuItemComponentProps) => {
         activeOpacity={!item.isTitle ? 0.4 : 1}
         style={[styles.menuItem, borderStyles]}
       >
-        <Text
+        <Animated.Text
           style={[
             item.isTitle ? styles.menuItemTitleText : styles.menuItemText,
             textColor,
           ]}
         >
           {item.text}
-        </Text>
+        </Animated.Text>
         {!item.isTitle && item.icon && item.icon()}
       </AnimatedTouchable>
-      {item.withSeparator && <Separator theme={theme} />}
+      {item.withSeperator && <Seperator />}
     </>
   );
 };

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -19,6 +19,7 @@ import {
   MENU_TEXT_LIGHT_COLOR,
 } from './constants';
 import isEqual from 'lodash.isequal';
+import { AnimatedIcon } from '../provider/Provider';
 
 const ItemComponent = IS_IOS ? TouchableOpacity : GHTouchableOpacity;
 const AnimatedTouchable = Animated.createAnimatedComponent(ItemComponent);
@@ -64,6 +65,10 @@ const MenuItemComponent = ({ item, isLast }: MenuItemComponentProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state, item]);
 
+  const iconStyle = useAnimatedStyle(() => {
+    return { color: theme.value === 'light' ? 'black' : 'white' };
+  }, [theme]);
+
   return (
     <>
       <AnimatedTouchable
@@ -79,7 +84,9 @@ const MenuItemComponent = ({ item, isLast }: MenuItemComponentProps) => {
         >
           {item.text}
         </Animated.Text>
-        {!item.isTitle && item.icon && item.icon()}
+        {!item.isTitle && item.icon && (
+          <AnimatedIcon name={item.icon} size={18} style={iconStyle} />
+        )}
       </AnimatedTouchable>
       {item.withSeperator && <Seperator />}
     </>

--- a/src/components/menu/MenuItems.tsx
+++ b/src/components/menu/MenuItems.tsx
@@ -5,13 +5,7 @@ import MenuItem from './MenuItem';
 import isEqual from 'lodash.isequal';
 import { MenuItemProps } from './types';
 
-const MenuItemsComponent = ({
-  items,
-  theme,
-}: {
-  items: MenuItemProps[];
-  theme: 'light' | 'dark';
-}) => {
+const MenuItemsComponent = ({ items }: { items: MenuItemProps[] }) => {
   return (
     <>
       {items.map((item: MenuItemProps, index: number) => {
@@ -20,7 +14,6 @@ const MenuItemsComponent = ({
             key={index}
             item={item}
             isLast={items.length === index + 1}
-            theme={theme}
           />
         );
       })}

--- a/src/components/menu/MenuList.tsx
+++ b/src/components/menu/MenuList.tsx
@@ -34,7 +34,9 @@ import { deepEqual } from '../../utils/validations';
 import { leftOrRight } from './calculations';
 
 const MenuContainerComponent = IS_IOS ? BlurView : View;
-const AnimatedView = Animated.createAnimatedComponent(MenuContainerComponent);
+const AnimatedView = Animated.createAnimatedComponent<{
+  animatedProps: Partial<{ blurType: string }>;
+}>(MenuContainerComponent);
 
 const MenuListComponent = () => {
   const { state, theme, menuProps } = useInternal();
@@ -140,7 +142,7 @@ const MenuListComponent = () => {
           animatedInnerContainerStyle,
         ]}
       >
-        <MenuItems items={itemList} theme={theme.value} />
+        <MenuItems items={itemList} />
       </Animated.View>
     </AnimatedView>
   );

--- a/src/components/menu/Separator.tsx
+++ b/src/components/menu/Separator.tsx
@@ -1,24 +1,28 @@
-import isEqual from 'lodash.isequal';
-import React, { memo, useMemo } from 'react';
-import { View } from 'react-native';
+import React, { memo } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
+import { useInternal } from '../../hooks';
 
 import { BORDER_LIGHT_COLOR, BORDER_DARK_COLOR } from './constants';
 
-type SeparatorProps = {
-  theme: 'light' | 'dark';
-};
+const Seperator = () => {
+  const { theme } = useInternal();
 
-const Separator = ({ theme }: SeparatorProps) => {
-  const styles = useMemo(() => {
+  const seperatorStyles = useAnimatedStyle(() => {
     return {
-      width: '100%',
-      height: 8,
       backgroundColor:
-        theme === 'dark' ? BORDER_DARK_COLOR : BORDER_LIGHT_COLOR,
+        theme.value === 'dark' ? BORDER_DARK_COLOR : BORDER_LIGHT_COLOR,
     };
   }, [theme]);
 
-  return <View style={styles} />;
+  return <Animated.View style={[styles.seperator, { ...seperatorStyles }]} />;
 };
 
-export default memo(Separator, isEqual);
+export default memo(Seperator);
+
+const styles = StyleSheet.create({
+  seperator: {
+    width: '100%',
+    height: 8,
+  },
+});

--- a/src/components/menu/types.d.ts
+++ b/src/components/menu/types.d.ts
@@ -2,7 +2,7 @@ import { TransformOriginAnchorPosition } from '../../utils/calculations';
 
 export type MenuItemProps = {
   text: string;
-  icon?: () => React.ReactNode;
+  icon?: string;
   onPress?: (arg?: string | number) => void;
   isTitle?: boolean;
   isDestructive?: boolean;

--- a/src/components/provider/Provider.tsx
+++ b/src/components/provider/Provider.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useEffect, useMemo } from 'react';
 import { PortalProvider } from '@gorhom/portal';
-import { useSharedValue } from 'react-native-reanimated';
+import Animated, { useSharedValue } from 'react-native-reanimated';
 import { InternalContext } from '../../context/internal';
 
 // Components
@@ -17,10 +17,15 @@ export interface Store {
   dispatch?: React.Dispatch<Action>;
 }
 
+export let AnimatedIcon: any;
+
 const ProviderComponent = ({
   children,
   theme: selectedTheme,
+  iconComponent,
 }: HoldMenuProviderProps) => {
+  AnimatedIcon = Animated.createAnimatedComponent(iconComponent);
+
   const state = useSharedValue<CONTEXT_MENU_STATE>(
     CONTEXT_MENU_STATE.UNDETERMINED
   );

--- a/src/components/provider/types.d.ts
+++ b/src/components/provider/types.d.ts
@@ -7,5 +7,6 @@ export interface HoldMenuProviderProps {
    * theme="light"
    */
   theme?: 'dark' | 'light';
+  iconComponent: any;
   children: React.ReactElement | React.ReactElement[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { default as HoldItem } from './components/holdItem';
 export { default as HoldMenuProvider } from './components/provider';
 export { default as HoldMenuFlatList } from './components/flatList';
+export { default as HoldMenuIcon } from './components/icon';

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -43,13 +43,15 @@ yarn add react-native-hold-menu
 This library needs these dependencies to be installed in your project before you can use it:
 
 ```bash
-yarn add react-native-reanimated@2.0.0-rc.0 react-native-gesture-handler
+yarn add react-native-reanimated@2.1.0 react-native-gesture-handler react-native-unimodules
 ```
 
 :::info
 **React Native Gesture Handler** needs extra steps to finalize its installation, please follow their [installation instructions](https://github.com/software-mansion/react-native-gesture-handler).
 
 **React Native Reanimated v2** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/installation).
+
+**React Native Unimodules** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.expo.io/bare/installing-unimodules/). And make sure you excluded unwanted modules in your app. You can check the [exampale project](https://github.com/enesozturk/react-native-hold-menu/tree/main/example).
 :::
 
 ## Todo

--- a/website/docs/props.md
+++ b/website/docs/props.md
@@ -10,22 +10,23 @@ slug: /props
 
 Array of menu items.
 
-| name          | type                          | required |
-| ------------- | ----------------------------- | -------- |
-| text          | string                        | YES      |
-| icon          | () => React.ReactNode \| null | NO       |
-| onPress       | function                      | YES      |
-| isTitle       | boolean                       | NO       |
-| isDestructive | boolean                       | NO       |
-| withSeparator | boolean                       | NO       |
+| name          | type     | required |
+| ------------- | -------- | -------- |
+| text          | string   | YES      |
+| icon          | string   | NO       |
+| onPress       | function | YES      |
+| isTitle       | boolean  | NO       |
+| isDestructive | boolean  | NO       |
+| withSeperator | boolean  | NO       |
 
 #### Example
 
 ```tsx
 <HoldItem
   items={[
-    { text: 'Action 1', icon: null, onPress: () => {} },
-    { text: 'Action 2', icon: null, onPress: () => {} },
+    { text: 'Actions', isTitle },
+    { text: 'Action 1', onPress: () => {} },
+    { text: 'Action 2', isDestructive, icon: 'trash', onPress: () => {} },
   ]}
 />
 ```
@@ -77,9 +78,9 @@ Type of behavior to activate menu action.
 
 Type of haptic feedback behavior.
 
-| type                                                                                              | default | required |
-| ------------------------------------------------------------------------------------------------- | ------- | -------- |
-| None <br/> Selection <br/> Light <br/> Medium <br/> Heavy <br/> Success <br/> Warning <br/> Error | Medium  | NO       |
+| value                                                                                                             | default  | required |
+| ----------------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| "None" <br/> "Selection" <br/> "Light" <br/> "Medium" <br/> "Heavy" <br/> "Success" <br/> "Warning" <br/> "Error" | "Medium" | NO       |
 
 #### Example
 
@@ -93,9 +94,9 @@ Menu anchor position is calculated automaticly. But you can override the calcula
 Auto calculation will be `top-left`, `top-center` or `top-right`. If you want to open menu from bottom, you need to use
 `bottom-left`, `bottom-center` or `bottom-right`. Or if you want to use auto calculation for bottom, see [`bottom`](#bottom) prop.
 
-| type                                                                                               | required |
-| -------------------------------------------------------------------------------------------------- | -------- |
-| top-center <br/> top-left <br/> top-right <br/> bottom-center <br/> bottom-left <br/> bottom-right | NO       |
+| value                                                                                                          | required |
+| -------------------------------------------------------------------------------------------------------------- | -------- |
+| "top-center" <br/> "top-left" <br/> "top-right" <br/> "bottom-center" <br/> "bottom-left" <br/> "bottom-right" | NO       |
 
 #### Example
 
@@ -113,6 +114,12 @@ you should set `bottom` as true.
 | ------- | ------- | -------- |
 | boolean | false   | NO       |
 
+#### Example
+
+```tsx
+<HoldItem menuAnchorPosition="top-center" bottom />
+```
+
 ### `disableMove`
 
 You may need disable move of holded item for your example. Set it true.
@@ -120,6 +127,12 @@ You may need disable move of holded item for your example. Set it true.
 | type    | default | required |
 | ------- | ------- | -------- |
 | boolean | false   | NO       |
+
+#### Example
+
+```tsx
+<HoldItem menuAnchorPosition="top-center" disableMove />
+```
 
 ### `styles`
 

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -8,6 +8,8 @@ hide_title: true
 
 ## Usage
 
+### Provider
+
 Before using Hold Menu in your application, you need to wrap your app with `HoldMenuProvider` first.
 
 ```tsx
@@ -26,6 +28,24 @@ const App = () => {
 export default App;
 ```
 
+### Icons
+
+If you want to use icon in your menu items, you need to set you Icon component to HoldMenuProvider to be able to use it. And than you can set just name of the icon in menu item list with `icon` prop like below.
+
+:::note
+Icon can be used with just **react-native-vector-icons** for now.
+:::
+
+```tsx
+import FeatherIcon from 'react-native-vector-icons/Feather';
+
+/* ... */
+<HoldMenuProvider iconComponent={FeatherIcon} theme="light">
+
+```
+
+### Wrapper
+
 Now you can wrap your components with `HoldItem`. You need to set [items](/react-native-hold-menu/docs/props#items) prop and also see other optional props for your menu.
 
 ```tsx
@@ -37,10 +57,10 @@ import { HoldItem } from 'react-native-hold-menu';
 import styles from './styles';
 
 const MenuItems = [
-  { text: 'Actions', isTitle: true, onPress: () => {} },
-  { text: 'Action 1', onPress: () => {} },
-  { text: 'Action 2', withSeparator: true, onPress: () => {} },
-  { text: 'Action 3', isDestructive: true, onPress: () => {} },
+  { text: 'Actions', icon: 'home', isTitle: true, onPress: () => {} },
+  { text: 'Action 1', icon: 'edit', onPress: () => {} },
+  { text: 'Action 2', icon: 'map-pin', withSeperator: true, onPress: () => {} },
+  { text: 'Action 3', icon: 'trash', isDestructive: true, onPress: () => {} },
 ];
 
 const Example = () => {

--- a/website/src/css/header.module.css
+++ b/website/src/css/header.module.css
@@ -88,7 +88,7 @@
   border: none;
   background: var(--ifm-color-emphasis-200);
   border-radius: 5px;
-  white-space: nowrap;
+  word-break: break-word;
   font-family: var(--mono-font-stack);
   font-size: 1rem;
   margin-left: 1em;


### PR DESCRIPTION
Previously, to use icon in `<MenuItem/>`, you have to provide icon component in list that goes with `items` prop of `<HoldMenu/>` component like below.

```js
const list = [
  {
  title: 'Home',
  icon: () => <Icon name="home" size={18} />
  },
  {
    title: 'Delete',
    icon: () => <Icon name="trash" size={18} />
   }
]

<HoldMenu items={list}>{...}</HoldMenu>
```

Now I decided to create animated icon component and use it in every `<MenuItem/>`. So only thing to do is providing an Icon component to `<HoldMenuProvider/>` and in the menu list, just set the name of the icon. It is possible to use Reanimated for the props for styles of the icon. I noticed that this made the animations little bit more performant. New usage is like below.
```js
const list = [
  { title: 'Home, icon: 'home' },
  { title: 'Trash', icon: 'trash' }
]

// In App.js
import FeatherIcon from 'react-native-vector-icons/Feather';

<HoldMenuProvider iconComponent={FeatherIcon} theme="light">
  {...}
</HoldMenuProvider>
```

### Cons
So far I worked with the 'react-native-vector-icons' for the example project. I will try to use expo vector icons as well and try to make it work. 