### PR TITLE
fix: deepEqual validator

### DIFF
--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -2,11 +2,10 @@ import { MenuItemProps } from '../components/menu/types';
 
 function fieldAreSame(obj1: MenuItemProps, obj2: MenuItemProps) {
   'worklet';
-  let areObjectsSame = true;
 
   const keys = Object.keys(obj1);
 
-  keys.forEach(key => {
+  return keys.every(key => {
     // @ts-ignore
     const val1 = obj1[key];
     // @ts-ignore
@@ -14,32 +13,30 @@ function fieldAreSame(obj1: MenuItemProps, obj2: MenuItemProps) {
 
     if (val1 !== val2) {
       if (typeof val1 === 'function' && typeof val2 === 'function')
-        areObjectsSame = val1.toString() === val2.toString();
-      else areObjectsSame = false;
+        return val1.toString() === val2.toString();
+      return false;
     }
-  });
 
-  return areObjectsSame;
+    return true;
+  });
 }
 
 function deepEqual(array1: MenuItemProps[], array2: MenuItemProps[]) {
   'worklet';
-  let areEqual = true;
 
   const areArrays = Array.isArray(array1) && Array.isArray(array2);
   const areSameLength = areArrays && array2 && array1.length === array2.length;
 
   if (areArrays && areSameLength && array2) {
-    array1.forEach((menuItem: MenuItemProps, index) => {
+    return array1.every((menuItem: MenuItemProps, index) => {
       const obj1 = menuItem;
       const obj2 = array2[index];
 
-      const isFieldsAreSame = fieldAreSame(obj1, obj2);
-      if (!isFieldsAreSame) areEqual = false;
+      return fieldAreSame(obj1, obj2);
     });
-  } else areEqual = false;
+  }
 
-  return areEqual;
+  return false;
 }
 
 export { deepEqual };


### PR DESCRIPTION
fixes  #47

## Problem: 
Logically it was returning the comparison of the last key field. 


## Solution:
Comparision should end as soon as any of the key fields is not equal, and return false.


## How to test?

```ts
const senderMenuItems = [ {text: 'Send', icon: 'trash'} ]
const receiverMenuItems = [ {text: 'Receiver', icon: 'trash'} ]
deepEqual(senderMenuItems, receiverMenuItems) // should return false
```