### PR TITLE
feat: new prop to HoldItem to enable bottom padding

### DIFF
--- a/src/components/holdItem/HoldItem.tsx
+++ b/src/components/holdItem/HoldItem.tsx
@@ -66,6 +66,7 @@ const HoldItemComponent = ({
   actionParams,
   closeOnTap,
   children,
+  paddingBottom = 0
 }: HoldItemProps) => {
   //#region hooks
   const { state, menuProps } = useInternal();
@@ -160,7 +161,8 @@ const HoldItemComponent = ({
           itemRectY.value +
           itemRectHeight.value +
           menuHeight +
-          styleGuide.spacing * 2;
+          styleGuide.spacing * 2 +
+          paddingBottom;
 
         tY = topTransform > height ? height - topTransform : 0;
       } else {

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -115,6 +115,15 @@ export type HoldItemProps = {
    * closeOnTap={true}
    */
   closeOnTap?: boolean;
+  
+  /**
+   * Set if you'd like to have a margin from the bottom
+   * @type number
+   * @default 0
+   * @examples
+   * paddingBottom={34}
+   */
+  paddingBottom?: number;
 };
 
 export type GestureHandlerProps = {


### PR DESCRIPTION
Introduces a new prop `paddingBottom`to `HoldItem `
This is useful for scenarios where a user LongPresses an item close to the bottom. 
There's no visual difference for items where the bottom position would be more than the `paddingBottom`

Example 
```
const Example = ({ items, children }) => {
  const { bottom } = useSafeAreaInsets()

  const items = useMemo(
    () => [
      {
        text: 'Bookmark',
        icon: 'bookmark',
      },
      { text: 'Like', icon: 'heart' },
      {
        text: 'Share',
        icon: 'share',
      },
    ],
    []
  )

  return (
    <HoldItem
      items={items}
      paddingBottom={bottom}
      menuAnchorPosition="top-left"
    >
      {children}
    </HoldItem>
  )
}
```