### PR TITLE
Feat: new prop to HoldItem to apply padding to the bottom

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,9 +1,0 @@
-/**
- * @format
- */
-
-import { AppRegistry } from 'react-native';
-import App from './src/App';
-import { name as appName } from './app.json';
-
-AppRegistry.registerComponent(appName, () => App);

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * @format
+ */
+
+import React from 'react';
+import { AppRegistry } from 'react-native';
+import App from './src/App';
+import { name as appName } from './app.json';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+const MainApp = () => {
+  return (
+    <SafeAreaProvider>
+      <App />
+    </SafeAreaProvider>
+  );
+};
+
+AppRegistry.registerComponent(appName, () => MainApp);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,6 +15,7 @@ import { StatusBar } from 'react-native';
 
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // Screens
 import Home, { ToggleThemeButton } from './screens/Home';
@@ -37,6 +38,7 @@ import StyleGuide from './utilities/styleGuide';
 const Stack = createStackNavigator();
 
 const App = () => {
+  const { bottom } = useSafeAreaInsets();
   const [state, setState] = useState<IAppContext>({
     theme: 'light',
     toggleTheme: () => {},
@@ -70,7 +72,11 @@ const App = () => {
         <StatusBar
           barStyle={state.theme === 'light' ? 'dark-content' : 'light-content'}
         />
-        <HoldMenuProvider iconComponent={FeatherIcon} theme={state.theme}>
+        <HoldMenuProvider
+          iconComponent={FeatherIcon}
+          theme={state.theme}
+          paddingBottom={bottom}
+        >
           <NavigationContainer>
             <Stack.Navigator
               initialRouteName="Home"

--- a/src/components/holdItem/HoldItem.tsx
+++ b/src/components/holdItem/HoldItem.tsx
@@ -66,6 +66,7 @@ const HoldItemComponent = ({
   actionParams,
   closeOnTap,
   children,
+  paddingBottom = 0,
 }: HoldItemProps) => {
   //#region hooks
   const { state, menuProps } = useInternal();
@@ -160,7 +161,8 @@ const HoldItemComponent = ({
           itemRectY.value +
           itemRectHeight.value +
           menuHeight +
-          styleGuide.spacing * 2;
+          styleGuide.spacing * 2 +
+          paddingBottom;
 
         tY = topTransform > height ? height - topTransform : 0;
       } else {

--- a/src/components/holdItem/HoldItem.tsx
+++ b/src/components/holdItem/HoldItem.tsx
@@ -66,10 +66,9 @@ const HoldItemComponent = ({
   actionParams,
   closeOnTap,
   children,
-  paddingBottom = 0,
 }: HoldItemProps) => {
   //#region hooks
-  const { state, menuProps } = useInternal();
+  const { state, menuProps, paddingBottom } = useInternal();
   const deviceOrientation = useDeviceOrientation();
   //#endregion
 
@@ -161,7 +160,7 @@ const HoldItemComponent = ({
           itemRectY.value +
           itemRectHeight.value +
           menuHeight +
-          styleGuide.spacing * 2 +
+          styleGuide.spacing +
           paddingBottom;
 
         tY = topTransform > height ? height - topTransform : 0;

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -115,6 +115,15 @@ export type HoldItemProps = {
    * closeOnTap={true}
    */
   closeOnTap?: boolean;
+
+  /**
+   * Set if you'd like to apply a padding to the bottom
+   * @type number
+   * @default 0
+   * @examples
+   * paddingBottom={34}
+   */
+  paddingBottom?: number;
 };
 
 export type GestureHandlerProps = {

--- a/src/components/holdItem/types.d.ts
+++ b/src/components/holdItem/types.d.ts
@@ -115,15 +115,6 @@ export type HoldItemProps = {
    * closeOnTap={true}
    */
   closeOnTap?: boolean;
-
-  /**
-   * Set if you'd like to apply a padding to the bottom
-   * @type number
-   * @default 0
-   * @examples
-   * paddingBottom={34}
-   */
-  paddingBottom?: number;
 };
 
 export type GestureHandlerProps = {

--- a/src/components/provider/Provider.tsx
+++ b/src/components/provider/Provider.tsx
@@ -23,6 +23,7 @@ const ProviderComponent = ({
   children,
   theme: selectedTheme,
   iconComponent,
+  paddingBottom,
 }: HoldMenuProviderProps) => {
   if (iconComponent)
     AnimatedIcon = Animated.createAnimatedComponent(iconComponent);
@@ -53,8 +54,9 @@ const ProviderComponent = ({
       state,
       theme,
       menuProps,
+      paddingBottom: paddingBottom || 0,
     }),
-    [state, theme, menuProps]
+    [state, theme, menuProps, paddingBottom]
   );
 
   return (

--- a/src/components/provider/types.d.ts
+++ b/src/components/provider/types.d.ts
@@ -9,4 +9,13 @@ export interface HoldMenuProviderProps {
   theme?: 'dark' | 'light';
   iconComponent?: any;
   children: React.ReactElement | React.ReactElement[];
+
+  /**
+   * Set if you'd like to apply padding to bottom (safe area bottom inset in most case)
+   * @type number
+   * @default 0
+   * @examples
+   * paddingBottom={34}
+   */
+  paddingBottom?: number;
 }

--- a/src/context/internal.ts
+++ b/src/context/internal.ts
@@ -7,6 +7,7 @@ export type InternalContextType = {
   state: Animated.SharedValue<CONTEXT_MENU_STATE>;
   theme: Animated.SharedValue<'light' | 'dark'>;
   menuProps: Animated.SharedValue<MenuInternalProps>;
+  paddingBottom: number;
 };
 
 // @ts-ignore


### PR DESCRIPTION
Introduces a new prop `paddingBottom`to `HoldItem `
This is useful for scenarios where a user LongPresses an item close to the bottom. 
There's no visual difference for items where the bottom position would be more than the `paddingBottom`

Example 
```
const Example = ({ items, children }) => {
  const { bottom } = useSafeAreaInsets()

  const items = useMemo(
    () => [
      {
        text: 'Bookmark',
        icon: 'bookmark',
      },
      { text: 'Like', icon: 'heart' },
      {
        text: 'Share',
        icon: 'share',
      },
    ],
    []
  )

  return (
    <HoldItem
      items={items}
      paddingBottom={bottom}
      menuAnchorPosition="top-left"
    >
      {children}
    </HoldItem>
  )
}
```