### PR TITLE
Support expo-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,6 @@
   },
   "dependencies": {
     "@gorhom/portal": "^1.0.3",
-    "expo-blur": "^9.0.0",
-    "expo-haptics": "^9.0.0",
     "lodash.isequal": "^4.5.0",
     "nanoid": "^3.1.20"
   },
@@ -75,6 +73,8 @@
     "typescript": "~4.0.0"
   },
   "peerDependencies": {
+    "expo-blur": ">=9.0.0",
+    "expo-haptics": ">=9.0.0",
     "react": "*",
     "react-native": "*",
     "react-native-gesture-handler": ">=1.8.0",

--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -43,7 +43,7 @@ yarn add react-native-hold-menu
 This library needs these dependencies to be installed in your project before you can use it:
 
 ```bash
-yarn add react-native-reanimated@2.1.0 react-native-gesture-handler react-native-unimodules
+yarn add react-native-reanimated@2.1.0 react-native-gesture-handler react-native-unimodules expo-blur expo-haptics
 ```
 
 :::info


### PR DESCRIPTION
As pointed on #53 since expo sdk 43 the `react-native-unimodules` is deprecated in favor of `expo-modules`, but this package installs the version 9.x of `expo-blur` & `expo-haptics` that uses unimodules.

This can be fixed by moving the dependecies to peers so it will rely on the ones that the main project has installed, avoiding any conflict and making it compatible with any expo sdk version.

Solves #53