### PR TITLE
feat: add safeAreaInsets prop

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -26,7 +26,7 @@ import StyleGuide from './utilities/styleGuide';
 const Stack = createStackNavigator();
 
 const App = () => {
-  const { bottom } = useSafeAreaInsets();
+  const safeAreaInsets = useSafeAreaInsets();
   const [state, setState] = useState<IAppContext>({
     theme: 'light',
     toggleTheme: () => {},
@@ -63,7 +63,7 @@ const App = () => {
         <HoldMenuProvider
           iconComponent={FeatherIcon}
           theme={state.theme}
-          paddingBottom={bottom}
+          safeAreaInsets={safeAreaInsets}
         >
           <NavigationContainer>
             <Stack.Navigator

--- a/src/components/holdItem/HoldItem.tsx
+++ b/src/components/holdItem/HoldItem.tsx
@@ -68,7 +68,7 @@ const HoldItemComponent = ({
   children,
 }: HoldItemProps) => {
   //#region hooks
-  const { state, menuProps, paddingBottom } = useInternal();
+  const { state, menuProps, safeAreaInsets } = useInternal();
   const deviceOrientation = useDeviceOrientation();
   //#endregion
 
@@ -161,13 +161,14 @@ const HoldItemComponent = ({
           itemRectHeight.value +
           menuHeight +
           styleGuide.spacing +
-          paddingBottom;
+          (safeAreaInsets?.bottom || 0);
 
         tY = topTransform > height ? height - topTransform : 0;
       } else {
-        const bototmTransform = itemRectY.value - menuHeight;
+        const bottomTransform =
+          itemRectY.value - menuHeight - (safeAreaInsets?.top || 0);
         tY =
-          bototmTransform < 0 ? -bototmTransform + styleGuide.spacing * 2 : 0;
+          bottomTransform < 0 ? -bottomTransform + styleGuide.spacing * 2 : 0;
       }
     }
     return tY;

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -64,8 +64,7 @@ const MenuItemComponent = ({ item, isLast }: MenuItemComponentProps) => {
         </Animated.Text>
         {!item.isTitle &&
           item.icon &&
-          AnimatedIcon &&
-          (typeof item.icon === 'string' ? (
+          (AnimatedIcon && typeof item.icon === 'string' ? (
             <AnimatedIcon name={item.icon} size={18} style={textColor} />
           ) : typeof item.icon === 'function' ? (
             item.icon()

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -67,9 +67,9 @@ const MenuItemComponent = ({ item, isLast }: MenuItemComponentProps) => {
           AnimatedIcon &&
           (typeof item.icon === 'string' ? (
             <AnimatedIcon name={item.icon} size={18} style={textColor} />
-          ) : (
+          ) : typeof item.icon === 'function' ? (
             item.icon()
-          ))}
+          ) : null)}
       </AnimatedTouchable>
       {item.withSeparator && <Separator />}
     </>

--- a/src/components/provider/Provider.tsx
+++ b/src/components/provider/Provider.tsx
@@ -44,7 +44,6 @@ const ProviderComponent = ({
     menuHeight: 0,
     transformValue: 0,
     actionParams: {},
-    previewEnabled: false,
   });
 
   useEffect(() => {

--- a/src/components/provider/Provider.tsx
+++ b/src/components/provider/Provider.tsx
@@ -25,7 +25,7 @@ const ProviderComponent = ({
   children,
   theme: selectedTheme,
   iconComponent,
-  paddingBottom,
+  safeAreaInsets,
 }: HoldMenuProviderProps) => {
   if (iconComponent)
     AnimatedIcon = Animated.createAnimatedComponent(iconComponent);
@@ -44,6 +44,7 @@ const ProviderComponent = ({
     menuHeight: 0,
     transformValue: 0,
     actionParams: {},
+    previewEnabled: false,
   });
 
   useEffect(() => {
@@ -56,9 +57,14 @@ const ProviderComponent = ({
       state,
       theme,
       menuProps,
-      paddingBottom: paddingBottom || 0,
+      safeAreaInsets: safeAreaInsets || {
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+      },
     }),
-    [state, theme, menuProps, paddingBottom]
+    [state, theme, menuProps, safeAreaInsets]
   );
 
   return (

--- a/src/components/provider/types.d.ts
+++ b/src/components/provider/types.d.ts
@@ -11,11 +11,20 @@ export interface HoldMenuProviderProps {
   children: React.ReactElement | React.ReactElement[];
 
   /**
-   * Set if you'd like to apply padding to bottom (safe area bottom inset in most case)
-   * @type number
-   * @default 0
+   * Set this to prevent the menu to be opened under the unsafe area.
+   * @type object
+   * @default
+   * { top: 0, bottom: 0, right: 0, left: 0 }
    * @examples
-   * paddingBottom={34}
+   * ```
+   * const insets = useSafeAreaInsets();
+   * safeAreaInsets={insets}
+   * ```
    */
-  paddingBottom?: number;
+  safeAreaInsets: {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  };
 }

--- a/src/context/internal.ts
+++ b/src/context/internal.ts
@@ -7,7 +7,12 @@ export type InternalContextType = {
   state: Animated.SharedValue<CONTEXT_MENU_STATE>;
   theme: Animated.SharedValue<'light' | 'dark'>;
   menuProps: Animated.SharedValue<MenuInternalProps>;
-  paddingBottom: number;
+  safeAreaInsets?: {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+  };
 };
 
 // @ts-ignore

--- a/website/docs/props.md
+++ b/website/docs/props.md
@@ -37,15 +37,15 @@ Values:
 <HoldMenuProvider theme={"dark"}>
 ```
 
-### `paddingBottom`
+### `safeAreaInsets`
 
-Set if you'd like to apply padding to bottom. In most cases, you may want to set this for safe area provider values.
+Set object of safe area inset values to prevent the menu to be opened under the unsafe area
 
 #### Example
 
 ```tsx
-const { bottom } = useSafeAreaProvider();
-<HoldMenuProvider paddingBottom={bottom} />;
+const safeAreaInsets = useSafeAreaProvider();
+<HoldMenuProvider safeAreaInsets={safeAreaInsets} />;
 ```
 
 ## HoldItem


### PR DESCRIPTION
### `safeAreaInsets` prop

To be able to provide a better experience on opening menus, safe areas should be considered for both top and bottom. To do this, instead of passing separated props, added `safeAreaInsets` prop.

Prev:
```js
const { bottom } = useSafeAreaInsets();
<HoldMenuProvider paddingBottom={bottom} />
```

Now:
```js
const safeAreaInsets = useSafeAreaInsets();
<HoldMenuProvider safeAreaInsets={safeAreaInsets} />
```