### PR TITLE
fix: fix for unreactive react keys

### DIFF
--- a/src/components/menu/MenuItems.tsx
+++ b/src/components/menu/MenuItems.tsx
@@ -11,7 +11,7 @@ const MenuItemsComponent = ({ items }: { items: MenuItemProps[] }) => {
       {items.map((item: MenuItemProps, index: number) => {
         return (
           <MenuItem
-            key={index}
+            key={item.key}
             item={item}
             isLast={items.length === index + 1}
           />

--- a/src/components/menu/types.d.ts
+++ b/src/components/menu/types.d.ts
@@ -1,6 +1,7 @@
 import { TransformOriginAnchorPosition } from '../../utils/calculations';
 
 export type MenuItemProps = {
+  key: string;
   text: string;
   icon?: string | (() => React.ReactElement);
   onPress?: (...args: any[]) => void;


### PR DESCRIPTION
# Summary

This addresses 
- https://github.com/enesozturk/react-native-hold-menu/issues/86
- https://github.com/enesozturk/react-native-hold-menu/issues/105
- https://github.com/enesozturk/react-native-hold-menu/issues/106

`MenuItems` uses an numeric `index` for reactive keys, so react has no idea that the item needs to be recomputed when the arrow function differs between two items but all other properties are the same. This should be exposed to the developers and required to prevent the side effect of the first `onPress` arrow function persisting for all items that only differ by their `onPress` property.