### PR TITLE
menu height is dynamic and needs to be reactive

### DIFF
--- a/src/components/holdItem/HoldItem.tsx
+++ b/src/components/holdItem/HoldItem.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import { ViewProps } from 'react-native';
+import { ViewProps, useWindowDimensions } from 'react-native';
 
 //#region reanimated & gesture handler
 import {
@@ -71,6 +71,7 @@ const HoldItemComponent = ({
   //#region hooks
   const { state, menuProps, safeAreaInsets } = useInternal();
   const deviceOrientation = useDeviceOrientation();
+  const { fontScale } = useWindowDimensions();
   //#endregion
 
   //#region variables
@@ -91,7 +92,7 @@ const HoldItemComponent = ({
   const key = useMemo(() => `hold-item-${nanoid()}`, []);
   const menuHeight = useMemo(() => {
     const itemsWithSeparator = items.filter(item => item.withSeparator);
-    return calculateMenuHeight(items.length, itemsWithSeparator.length);
+    return calculateMenuHeight(fontScale, items.length, itemsWithSeparator.length);
   }, [items]);
 
   const isHold = !activateOn || activateOn === 'hold';
@@ -128,6 +129,7 @@ const HoldItemComponent = ({
     'worklet';
     if (!ctx.didMeasureLayout) {
       const measured = measure(containerRef);
+      if (!measured) return;
 
       itemRectY.value = measured.pageY;
       itemRectX.value = measured.pageX;

--- a/src/components/menu/MenuList.tsx
+++ b/src/components/menu/MenuList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, useWindowDimensions } from 'react-native';
 
 import Animated, {
   runOnJS,
@@ -37,6 +37,7 @@ const AnimatedView = Animated.createAnimatedComponent(BlurView);
 
 const MenuListComponent = () => {
   const { state, theme, menuProps } = useInternal();
+  const { fontScale } = useWindowDimensions();
 
   const [itemList, setItemList] = React.useState<MenuItemProps[]>([]);
 
@@ -45,6 +46,7 @@ const MenuListComponent = () => {
       item => item.withSeparator
     );
     return calculateMenuHeight(
+      fontScale,
       menuProps.value.items.length,
       itemsWithSeparator.length
     );
@@ -57,6 +59,7 @@ const MenuListComponent = () => {
     );
 
     const translate = menuAnimationAnchor(
+      fontScale,
       menuProps.value.anchorPosition,
       menuProps.value.itemWidth,
       menuProps.value.items.length,

--- a/src/hooks/useDeviceOrientation.ts
+++ b/src/hooks/useDeviceOrientation.ts
@@ -1,27 +1,11 @@
-import { useState, useEffect } from 'react';
-import { Dimensions } from 'react-native';
+import { useMemo } from 'react';
+import { useWindowDimensions } from 'react-native';
 
 type Orientation = 'landscape' | 'portrait';
 
-function getWindowOrientation(): Orientation {
-  const { width, height } = Dimensions.get('window');
-  return height >= width ? 'portrait' : 'landscape';
-}
-
 function useDeviceOrientation() {
-  const [deviceOrientation, setDeviceOrientation] = useState<Orientation>(
-    getWindowOrientation()
-  );
-
-  useEffect(() => {
-    function updateState() {
-      setDeviceOrientation(getWindowOrientation());
-    }
-    const changeEvent = Dimensions.addEventListener('change', updateState);
-    // @ts-ignore
-    return () => changeEvent.remove();
-  }, []);
-
+  const { width, height } = useWindowDimensions();
+  const deviceOrientation = useMemo<Orientation>(() => height >= width ? 'portrait' : 'landscape', [width, height]);
   return deviceOrientation;
 }
 

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -2,24 +2,24 @@ import styleGuide from '../styleGuide';
 import {
   MENU_WIDTH,
   MENU_TRANSFORM_ORIGIN_TOLERENCE,
-  FONT_SCALE,
 } from '../constants';
 
-export const MenuItemHeight = () => {
+export const MenuItemHeight = (fontScale: number) => {
   'worklet';
   return (
-    styleGuide.typography.callout.lineHeight * FONT_SCALE +
+    styleGuide.typography.callout.lineHeight * fontScale +
     styleGuide.spacing * 2.5
   );
 };
 
 export const calculateMenuHeight = (
+  fontScale: number,
   itemLength: number,
   separatorCount: number
 ) => {
   'worklet';
   return (
-    MenuItemHeight() * itemLength +
+    MenuItemHeight(fontScale) * itemLength +
     (itemLength - 1) +
     separatorCount * styleGuide.spacing
   );
@@ -34,13 +34,14 @@ export type TransformOriginAnchorPosition =
   | 'bottom-center';
 
 export const menuAnimationAnchor = (
+  fontScale: number,
   anchorPoint: TransformOriginAnchorPosition,
   itemWidth: number,
   itemLength: number,
   itemsWithSeparatorLength: number
 ) => {
   'worklet';
-  const MenuHeight = calculateMenuHeight(itemLength, itemsWithSeparatorLength);
+  const MenuHeight = calculateMenuHeight(fontScale, itemLength, itemsWithSeparatorLength);
   const splittetAnchorName: string[] = anchorPoint.split('-');
 
   const Center1 = itemWidth;


### PR DESCRIPTION
# Summary

First off, love this library! I've learned a great deal about reanimated, and continuing to learn more!

A lot of the variables defined as "constants" really are not constants, because they can change randomly at runtime. This is especially important if the screen is rotated at the same time as launch, data populating the menu is asynchronous, or the variable values are loaded on demand in a flatlist. This particular PR fixes an in production issue, where the first item is not calculating the font scale correctly because a reactive hook is not used to capture the `fontScale` memoized property of `Dimensions`. The below videos indicate what this is fixing, although a lot of other reactive issues may still need to be addressed as they reveal themselves.

## Without Fix
https://github.com/enesozturk/react-native-hold-menu/assets/14790443/3eb4d630-080c-485c-864a-457e0888a921

## With Fix
https://github.com/enesozturk/react-native-hold-menu/assets/14790443/ec3af9b6-1338-4fb9-8b16-0231ecd56356

